### PR TITLE
Retter mime-type for skriving av data

### DIFF
--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -211,7 +211,7 @@ paths:
         description: Optional description in *Markdown*
         required: true
         content:
-          application/vnd.kartverket.sosi+gml:
+          application/vnd.kartverket.sosi+wfs-t:
            schema:
             type: object
            


### PR DESCRIPTION
I spesifikasjonen står det at både POST og GET for `/datasets/{datasetid}/features` skal hhv. ta inn og returnere ` application/vnd.kartverket.sosi+gml`. Dette er ikke riktig, da skriving skal ta inn WFS-T - dette står også i rapporten under eksempler. Derfor rettes MIME-typen for POST til `application/vnd.kartverket.sosi+wfs-t`, slik at det er tydelig at det er forskjell på dataene - de har ulike formater.