### PR TITLE
Retter formen på låse-query-parameter

### DIFF
--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -106,12 +106,12 @@ paths:
           description: UUID of the dataset to get
         - in: query
           name: lock
-          style: deepObject
+          style: form
           explode: true
           schema:
             type: object
             properties:
-              type:
+              locktype:
                 type: string
                 enum: [user_lock,lock_id,optimistic_locking]
               id:
@@ -122,7 +122,7 @@ paths:
           description: |
             Låser objektene som hentes ut for oppdatering. Krever skrivetilgang mot dataset'et.
             
-            Foreløpig er det kun brukerlås (lock[type]=user_lock) som støttes. Kallet legger da til objekter i brukerlåsen. 
+            Foreløpig er det kun brukerlås (locktype=user_lock) som støttes. Kallet legger da til objekter i brukerlåsen. 
             Låsen vil fjernes neste gang brukeren skriver data til dataset'et, eller dersom låsen slettes.
         - in: query
           name: bbox
@@ -204,12 +204,12 @@ paths:
           description: UUID of the dataset to get
         - in: query
           name: lock
-          style: deepObject
+          style: form
           explode: true
           schema:
             type: object
             properties:
-              type:
+              locktype:
                 type: string
                 enum: [user_lock,lock_id,optimistic_locking]
               id:
@@ -220,7 +220,7 @@ paths:
           description: |
             Låser objektene som hentes ut for oppdatering. Krever skrivetilgang mot dataset'et.
             
-            Foreløpig er det kun brukerlås (lock[type]=user_lock) som støttes. Kallet legger da til objekter i brukerlåsen. 
+            Foreløpig er det kun brukerlås (locktype=user_lock) som støttes. Kallet legger da til objekter i brukerlåsen. 
             Låsen vil fjernes neste gang brukeren skriver data til dataset'et, eller dersom låsen slettes.
       requestBody:
         description: Optional description in *Markdown*

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -106,6 +106,8 @@ paths:
           description: UUID of the dataset to get
         - in: query
           name: lock
+          style: deepObject
+          explode: true
           schema:
             type: object
             properties:
@@ -120,7 +122,7 @@ paths:
           description: |
             Låser objektene som hentes ut for oppdatering. Krever skrivetilgang mot dataset'et.
             
-            Foreløpig er det kun brukerlås (user_lock) som støttes. Kallet legger da til objekter i brukerlåsen. 
+            Foreløpig er det kun brukerlås (lock[type]=user_lock) som støttes. Kallet legger da til objekter i brukerlåsen. 
             Låsen vil fjernes neste gang brukeren skriver data til dataset'et, eller dersom låsen slettes.
         - in: query
           name: bbox
@@ -202,6 +204,8 @@ paths:
           description: UUID of the dataset to get
         - in: query
           name: lock
+          style: deepObject
+          explode: true
           schema:
             type: object
             properties:
@@ -214,7 +218,10 @@ paths:
             required:
               - type
           description: |
-            TODO: Beskrive låsing
+            Låser objektene som hentes ut for oppdatering. Krever skrivetilgang mot dataset'et.
+            
+            Foreløpig er det kun brukerlås (lock[type]=user_lock) som støttes. Kallet legger da til objekter i brukerlåsen. 
+            Låsen vil fjernes neste gang brukeren skriver data til dataset'et, eller dersom låsen slettes.
       requestBody:
         description: Optional description in *Markdown*
         required: true

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -105,13 +105,13 @@ paths:
           required: true
           description: UUID of the dataset to get
         - in: query
-          name: lock
-          style: form
+          name: locking
+          style: deepObject
           explode: true
           schema:
             type: object
             properties:
-              locktype:
+              type:
                 type: string
                 enum: [user_lock,lock_id,optimistic_locking]
               id:
@@ -122,7 +122,7 @@ paths:
           description: |
             Låser objektene som hentes ut for oppdatering. Krever skrivetilgang mot dataset'et.
             
-            Foreløpig er det kun brukerlås (locktype=user_lock) som støttes. Kallet legger da til objekter i brukerlåsen. 
+            Foreløpig er det kun brukerlås (lock[type]=user_lock) som støttes. Kallet legger da til objekter i brukerlåsen. 
             Låsen vil fjernes neste gang brukeren skriver data til dataset'et, eller dersom låsen slettes.
         - in: query
           name: bbox
@@ -203,13 +203,13 @@ paths:
           required: true
           description: UUID of the dataset to get
         - in: query
-          name: lock
-          style: form
+          name: locking
+          style: deepObject
           explode: true
           schema:
             type: object
             properties:
-              locktype:
+              type:
                 type: string
                 enum: [user_lock,lock_id,optimistic_locking]
               id:
@@ -220,7 +220,7 @@ paths:
           description: |
             Låser objektene som hentes ut for oppdatering. Krever skrivetilgang mot dataset'et.
             
-            Foreløpig er det kun brukerlås (locktype=user_lock) som støttes. Kallet legger da til objekter i brukerlåsen. 
+            Foreløpig er det kun brukerlås (lock[type]=user_lock) som støttes. Kallet legger da til objekter i brukerlåsen. 
             Låsen vil fjernes neste gang brukeren skriver data til dataset'et, eller dersom låsen slettes.
       requestBody:
         description: Optional description in *Markdown*

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -122,7 +122,7 @@ paths:
           description: |
             Låser objektene som hentes ut for oppdatering. Krever skrivetilgang mot dataset'et.
             
-            Foreløpig er det kun brukerlås (lock[type]=user_lock) som støttes. Kallet legger da til objekter i brukerlåsen. 
+            Foreløpig er det kun brukerlås (locking[type]=user_lock) som støttes. Kallet legger da til objekter i brukerlåsen. 
             Låsen vil fjernes neste gang brukeren skriver data til dataset'et, eller dersom låsen slettes.
         - in: query
           name: bbox
@@ -220,7 +220,7 @@ paths:
           description: |
             Låser objektene som hentes ut for oppdatering. Krever skrivetilgang mot dataset'et.
             
-            Foreløpig er det kun brukerlås (lock[type]=user_lock) som støttes. Kallet legger da til objekter i brukerlåsen. 
+            Foreløpig er det kun brukerlås (locking[type]=user_lock) som støttes. Kallet legger da til objekter i brukerlåsen. 
             Låsen vil fjernes neste gang brukeren skriver data til dataset'et, eller dersom låsen slettes.
       requestBody:
         description: Optional description in *Markdown*


### PR DESCRIPTION
Jeg har lurt litt på hvordan det er best at låsing skal angis som parameter. I dag finnes kun én låsetype (brukerlås), men vi vil nok få støtte for flere etter hvert, der det f.eks må være mulig å sende med flere parametre. 

Slik det er nå vil spørrestrengen for låser bli `?lock[type]=user_lock` og når/hvis vi får støtte for dagens låser: `?lock[type]=lock_id&lock[id]=5432`.

Dette er beskrevet i dokumentasjonen for OpenAPI her: https://swagger.io/docs/specification/serialization/