### PR TITLE
Forbedret grensesnitt ved uthenting og sletting av låser

### DIFF
--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -104,26 +104,7 @@ paths:
             format: uuid
           required: true
           description: UUID of the dataset to get
-        - in: query
-          name: locking
-          style: deepObject
-          explode: true
-          schema:
-            type: object
-            properties:
-              type:
-                type: string
-                enum: [user_lock,lock_id,optimistic_locking]
-              id:
-                type: integer
-                minimum: 1
-            required:
-              - type
-          description: |
-            Låser objektene som hentes ut for oppdatering. Krever skrivetilgang mot dataset'et.
-            
-            Foreløpig er det kun brukerlås (locking[type]=user_lock) som støttes. Kallet legger da til objekter i brukerlåsen. 
-            Låsen vil fjernes neste gang brukeren skriver data til dataset'et, eller dersom låsen slettes.
+        - $ref: '#/components/parameters/lockingParam'
         - in: query
           name: bbox
           schema:
@@ -202,26 +183,7 @@ paths:
             format: uuid
           required: true
           description: UUID of the dataset to get
-        - in: query
-          name: locking
-          style: deepObject
-          explode: true
-          schema:
-            type: object
-            properties:
-              type:
-                type: string
-                enum: [user_lock,lock_id,optimistic_locking]
-              id:
-                type: integer
-                minimum: 1
-            required:
-              - type
-          description: |
-            Låser objektene som hentes ut for oppdatering. Krever skrivetilgang mot dataset'et.
-            
-            Foreløpig er det kun brukerlås (locking[type]=user_lock) som støttes. Kallet legger da til objekter i brukerlåsen. 
-            Låsen vil fjernes neste gang brukeren skriver data til dataset'et, eller dersom låsen slettes.
+        - $ref: '#/components/parameters/lockingParam'
       requestBody:
         description: Optional description in *Markdown*
         required: true
@@ -268,6 +230,7 @@ paths:
             format: uuid
           required: true
           description: UUID of the dataset to get
+        - $ref: '#/components/parameters/lockingParam'
       responses:
         '200':      # Response
           description: OK
@@ -296,6 +259,7 @@ paths:
             format: uuid
           required: true
           description: UUID of the dataset to delete locks in
+        - $ref: '#/components/parameters/lockingParam'
       responses:
         '204': # Success
           description: No Content
@@ -422,3 +386,25 @@ components:
         - title
         - detail
        
+  parameters:
+    lockingParam:
+      in: query
+      name: locking
+      style: deepObject
+      explode: true
+      schema:
+        type: object
+        properties:
+          type:
+            type: string
+            enum: [user_lock,lock_id,optimistic_locking]
+          id:
+            type: integer
+            minimum: 1
+        required:
+          - type
+      description: |
+        Låser objektene som hentes ut for oppdatering. Krever skrivetilgang mot dataset'et.
+        
+        Foreløpig er det kun brukerlås (locking[type]=user_lock) som støttes. Kallet legger da til objekter i brukerlåsen. 
+        Låsen vil fjernes neste gang brukeren skriver data til dataset'et, eller dersom låsen slettes.


### PR DESCRIPTION
Faktorerer ut låsing og legger på låseparametre ved uthenting og fjerning av låser

Dette er for å tydeliggjøre hvilke låser som hentes og slettes, siden det kan være
flere låser mot objektene som ikke er synlige (f.eks ved samtidig jobbing fra klienter
som bruker NGIS-APIet). Ved å justere dette nå, blir det enklere å innføre støtte for
dagens låser fra eksisterende klienter.

Dette ble klart for meg ved en intern demo der det ikke var tydelig nok at man kun hentet ut og fjernet kun brukerlåser (`user_lock`).