### PR TITLE
Legger inn støtte for geojson ved henting av data

### DIFF
--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -158,6 +158,9 @@ paths:
             application/vnd.kartverket.sosi+gml; version=1.0:
              schema:
               type: object
+            application/vnd.kartverket.sosi+json; version=1.0:
+             schema:
+              type: object
         '401':
           description: Gyldig autentisering av brukeren mangler eller er ugyldig
         '403':


### PR DESCRIPTION
Støtte for å hente ut data på "geojson"-format er støttet. Avventer skriving av geojson til dette er på plass.

Ved å legge det inn blir det enklere å teste via swagger-dokumentasjon fra readme-fila.