### PR TITLE
Legge inn MIME-type på alle responser

### DIFF
--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -47,7 +47,7 @@ paths:
         '200':      # Response
           description: OK
           content:  # Response body
-            application/json:  # Media type
+            application/vnd.kartverket.ngis.datasets+json:  # Media type
               schema: 
                 type: array
                 items:
@@ -77,7 +77,7 @@ paths:
         '200':      # Response
           description: OK
           content:  # Response body
-            application/json:  # Media type
+            application/vnd.kartverket.ngis.dataset+json:  # Media type
              schema: 
                $ref: '#/components/schemas/Dataset'    # Reference to object definition
         '401':
@@ -301,7 +301,7 @@ paths:
         '200':      # Response
           description: OK
           content:  # Response body
-            application/json:  # Media type
+            application/vnd.kartverket.ngis.locks+json:  # Media type
              schema: 
                $ref: '#/components/schemas/Locks'    # Reference to object definition
         '401':


### PR DESCRIPTION
Årsaken er å kunne skille mellom forskjellige responser i fremtiden, slik at vi kan unngå å endre api-versjonen, eksperimentere med andre responser osv.

Et eksempel er hvis vi ønsker å støtte f.eks `GET /dataset/{datasetId}/locks` med utvidet eller redusert informasjon. Da kan vi innføre en ny content-type i stedet for å øke versjonsnummeret, og eksisterende klienter blir ikke påvirket. 