### PR TITLE
Støtte for filter på objekttype i query-parameter

### DIFF
--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -214,6 +214,16 @@ paths:
               summary: Spørring etter flere objekter med lokalid
               description: |
                 Når objekt(er) hentes ut med lokalid er det normalt ikke nødvendig å filtrere på objekttype, derfor er objekttypen angitt med `*`.
+            feature_type:
+              value: 'eq(*,Bygning)'
+              summary: Spørring etter alle objekter med en bestemt objekttype
+              description: |
+                Vi bruker `*` for å angi at vi kun filtrerer på objekttype.
+            feature_type_multi:
+              value: 'in(*,Bygning,AnnenBygning)'
+              summary: Spørring etter flere objekter med lokalid
+              description: |
+                Vi bruker `*` for å angi at vi kun filtrerer på objekttype.
 
             
             

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -224,28 +224,6 @@ paths:
               summary: Spørring etter flere objekter med lokalid
               description: |
                 Vi bruker `*` for å angi at vi kun filtrerer på objekttype.
-
-            
-            
-
-        - in: query
-          name: feature_types
-          style: form
-          explode: false
-          schema:
-            type: array
-            minItems: 1
-            items:
-              type: string
-          examples:
-            feature_types1:
-              summary: Spesifikke Bygninger
-              description: |
-                NB! Bruk references-parameteret for å styre om også tilhørende linjer skal tas med
-              value: ['Bygning', 'AnnenBygning']
-          description: |
-            Henter kun ut objekter med en bestemt objekttype.
-      
       responses:
         '200':      # Response
           description: OK


### PR DESCRIPTION
Siden vi allerede støtter `*` for å angi vilkårlig objekttype, og det vi filtrerer på alltid er siste del av "stien" i `eq` og `in`, passer det kanskje enda bedre å integrere objekttype-filter på denne måten?

Jeg liker egentlig denne bedre enn `feature_types= ... `, og den blir lettere å implementere... :)

closes #74 